### PR TITLE
[hook] fix gradient erorr with buffer

### DIFF
--- a/elixir/chunk/core/group.py
+++ b/elixir/chunk/core/group.py
@@ -116,9 +116,7 @@ class ChunkGroup(object):
     def rcache_enough_check(self, chunk: Chunk) -> bool:
         if chunk.rcache_fused:
             return True
-        # the flag of free block list
-        flag = bool(self.rcache.public_free_blocks)
-        return flag
+        return self.rcache.public_free_cnt > 0
 
     def access_chunk(self, chunk: Chunk) -> bool:
         self.inside_check(chunk)
@@ -149,6 +147,7 @@ class ChunkGroup(object):
         self.inside_check(chunk)
         assert self.is_accessed(chunk)
         assert chunk.reduce_check
+        print('REDUCE', chunk.chunk_id)
 
         block = chunk.reduce_chunk()
         if block:

--- a/elixir/chunk/core/group.py
+++ b/elixir/chunk/core/group.py
@@ -147,7 +147,6 @@ class ChunkGroup(object):
         self.inside_check(chunk)
         assert self.is_accessed(chunk)
         assert chunk.reduce_check
-        print('REDUCE', chunk.chunk_id)
 
         block = chunk.reduce_chunk()
         if block:

--- a/elixir/chunk/core/memory_pool.py
+++ b/elixir/chunk/core/memory_pool.py
@@ -140,7 +140,6 @@ class MemoryPool(object):
     def free_public_block(self, block: TensorBlock):
         assert isinstance(block, PublicBlock)
         assert block in self.public_used_blocks
-        torch.zero_(block.payload)
 
         self.public_free_cnt += 1
         self.public_used_cnt -= 1

--- a/elixir/chunk/core/memory_pool.py
+++ b/elixir/chunk/core/memory_pool.py
@@ -140,6 +140,7 @@ class MemoryPool(object):
     def free_public_block(self, block: TensorBlock):
         assert isinstance(block, PublicBlock)
         assert block in self.public_used_blocks
+        torch.zero_(block.payload)
 
         self.public_free_cnt += 1
         self.public_used_cnt -= 1

--- a/elixir/chunk/fetcher.py
+++ b/elixir/chunk/fetcher.py
@@ -94,14 +94,14 @@ class ChunkFetcher(object):
             # if the rcache is not enough, just release a chunk
             if not self.group.rcache_enough_check(chunk):
                 maybe_chunk = self.scheduler.top()
-                print(f'Evicting {chunk.chunk_id} -> {maybe_chunk.chunk_id}')
+                # print(f'Evicting {chunk.chunk_id} -> {maybe_chunk.chunk_id}')
                 if maybe_chunk is None:
                     raise RuntimeError('R cache is not enough. Try to allocate more.')
                 self.scheduler.remove(maybe_chunk)
                 self.group.release_chunk(maybe_chunk)
 
+            # print('Accessing', chunk.chunk_id)
             self.group.access_chunk(chunk)
-            print('ACCESS', chunk.chunk_id, chunk.rcb.payload.data_ptr())
 
     def reduce_chunk(self, chunk: Chunk) -> bool:
         if not chunk.reduce_check:

--- a/elixir/chunk/fetcher.py
+++ b/elixir/chunk/fetcher.py
@@ -90,16 +90,18 @@ class ChunkFetcher(object):
         if self.reducing_chunk is not None:
             self.wait_reduce()
 
-        for chunk in chunks:
+        for chunk in scattered:
             # if the rcache is not enough, just release a chunk
             if not self.group.rcache_enough_check(chunk):
                 maybe_chunk = self.scheduler.top()
+                print(f'Evicting {chunk.chunk_id} -> {maybe_chunk.chunk_id}')
                 if maybe_chunk is None:
                     raise RuntimeError('R cache is not enough. Try to allocate more.')
                 self.scheduler.remove(maybe_chunk)
                 self.group.release_chunk(maybe_chunk)
 
             self.group.access_chunk(chunk)
+            print('ACCESS', chunk.chunk_id, chunk.rcb.payload.data_ptr())
 
     def reduce_chunk(self, chunk: Chunk) -> bool:
         if not chunk.reduce_check:

--- a/elixir/hook/__init__.py
+++ b/elixir/hook/__init__.py
@@ -1,2 +1,3 @@
 from .parameter import HookParam
+from .storage import BufferStore
 from .temp import hook_transform

--- a/elixir/hook/functions.py
+++ b/elixir/hook/functions.py
@@ -28,10 +28,6 @@ def prefwd_postbwd_function(fetcher: ChunkFetcher, store: BufferStore):
         @staticmethod
         def backward(ctx, *grads):
             with torch._C.DisableTorchFunction():
-                print('grad You know', end=' ')
-                for g in grads:
-                    print(torch.sum(g), end=' ')
-                print('')
                 fetcher.trans_to_hold(ctx.params, phase='b')
 
                 for p in ctx.params:
@@ -52,6 +48,7 @@ def postfwd_prebwd_function(fetcher: ChunkFetcher, store: BufferStore):
             with torch._C.DisableTorchFunction():
                 ctx.params = params
 
+                fetcher.trans_to_hold(ctx.params, phase='f')
                 for p in ctx.params:
                     if not fetcher.is_in_fused(p):
                         store.erase(p)
@@ -71,18 +68,6 @@ def postfwd_prebwd_function(fetcher: ChunkFetcher, store: BufferStore):
                         # because their blocks may be changed
                         offset = store.insert(p, offset)
 
-                print('grad before', end=' ')
-                for g in grads:
-                    print(torch.sum(g), g.data_ptr(), end=' ')
-                print('')
-                print('fetching', end=' ')
-                for c in chunks:
-                    print(c.chunk_id, c.rcb.payload.data_ptr(), end=' ')
-                print('')
-                print('grad after', end=' ')
-                for g in grads:
-                    print(torch.sum(g), end=' ')
-                print('')
             return (None, *grads)
 
     return PostFwdPreBwd.apply

--- a/elixir/hook/functions.py
+++ b/elixir/hook/functions.py
@@ -2,14 +2,27 @@ import torch
 
 from elixir.chunk import ChunkFetcher
 
+from .storage import BufferStore
 
-def prefwd_postbwd_function(fetcher: ChunkFetcher):
+
+def prefwd_postbwd_function(fetcher: ChunkFetcher, store: BufferStore):
 
     class PreFwdPostBwd(torch.autograd.Function):
 
         @staticmethod
         def forward(ctx, params, *args):
-            ctx.params = params
+            with torch._C.DisableTorchFunction():
+                ctx.params = params
+                chunks = fetcher.trans_to_compute(params)
+                fetcher.fetch_chunks(chunks)
+
+                offset = 0
+                for p in ctx.params:
+                    if not fetcher.is_in_fused(p):
+                        # we should add parameters to buffer
+                        # because their blocks may be changed
+                        offset = store.insert(p, offset)
+
             return args
 
         @staticmethod
@@ -20,23 +33,29 @@ def prefwd_postbwd_function(fetcher: ChunkFetcher):
                     print(torch.sum(g), end=' ')
                 print('')
                 fetcher.trans_to_hold(ctx.params, phase='b')
-                return (None, *grads)
 
-    def exec_func(params, *args):
-        chunks = fetcher.trans_to_compute(params)
-        fetcher.fetch_chunks(chunks)
-        return PreFwdPostBwd.apply(params, *args)
+                for p in ctx.params:
+                    if not fetcher.is_in_fused(p):
+                        store.erase(p)
 
-    return exec_func
+            return (None, *grads)
+
+    return PreFwdPostBwd.apply
 
 
-def postfwd_prebwd_function(fetcher: ChunkFetcher):
+def postfwd_prebwd_function(fetcher: ChunkFetcher, store: BufferStore):
 
     class PostFwdPreBwd(torch.autograd.Function):
 
         @staticmethod
         def forward(ctx, params, *args):
-            ctx.params = params
+            with torch._C.DisableTorchFunction():
+                ctx.params = params
+
+                for p in ctx.params:
+                    if not fetcher.is_in_fused(p):
+                        store.erase(p)
+
             return args
 
         @staticmethod
@@ -44,6 +63,14 @@ def postfwd_prebwd_function(fetcher: ChunkFetcher):
             with torch._C.DisableTorchFunction():
                 chunks = fetcher.trans_to_compute(ctx.params)
                 fetcher.fetch_chunks(chunks)
+
+                offset = 0
+                for p in ctx.params:
+                    if not fetcher.is_in_fused(p):
+                        # we should add parameters to buffer
+                        # because their blocks may be changed
+                        offset = store.insert(p, offset)
+
                 print('grad before', end=' ')
                 for g in grads:
                     print(torch.sum(g), g.data_ptr(), end=' ')
@@ -56,10 +83,6 @@ def postfwd_prebwd_function(fetcher: ChunkFetcher):
                 for g in grads:
                     print(torch.sum(g), end=' ')
                 print('')
-                return (None, *grads)
+            return (None, *grads)
 
-    def exec_func(params, *args):
-        fetcher.trans_to_hold(params, phase='f')
-        return PostFwdPreBwd.apply(params, *args)
-
-    return exec_func
+    return PostFwdPreBwd.apply

--- a/elixir/hook/parameter.py
+++ b/elixir/hook/parameter.py
@@ -47,7 +47,7 @@ class HookParam(OutplaceTensor, nn.Parameter):
 
         params = tuple(params_to_index.keys())
         with torch._C.DisableTorchFunction():
-            new_params = HookParam.pre_fwd_func.apply(params, *params)
+            new_params = HookParam.pre_fwd_func(params, *params)
 
         def replace_param(x):
             if isinstance(x, HookParam):
@@ -70,7 +70,7 @@ class HookParam(OutplaceTensor, nn.Parameter):
 
         ret = tree_map(clone_inplace_tensor, ret)
         with torch._C.DisableTorchFunction():
-            ret = HookParam.post_fwd_func.apply(params, *ret)
+            ret = HookParam.post_fwd_func(params, *ret)
 
         def convert(t):
             if isinstance(t, torch.Tensor):

--- a/elixir/hook/storage.py
+++ b/elixir/hook/storage.py
@@ -1,0 +1,41 @@
+import torch
+from torch.autograd.profiler_util import _format_memory
+
+from elixir import gpu_device
+
+
+class BufferStore(object):
+    """A place to store parameters temporarily when computing.
+    """
+
+    def __init__(self, buffer_size: torch.Tensor, buffer_dtype: torch.dtype) -> None:
+        super().__init__()
+        self.buffer_size = buffer_size
+        self.buffer_dtype = buffer_dtype
+        self.buffer: torch.Tensor = torch.empty(buffer_size, dtype=buffer_dtype, device=gpu_device())
+        self.buffer_occ = buffer_size * self.buffer.element_size()
+        self.record_dict = dict()
+
+    def insert(self, t: torch.Tensor, offset: int) -> int:
+        assert t not in self.record_dict
+        end = offset + t.numel()
+        assert end <= self.buffer_size, f'buffer size is {self.buffer_size} but needs {end}'
+
+        new_data = self.buffer[offset:end].view(t.shape)
+        new_data.copy_(t.data)
+
+        self.record_dict[t] = t.data
+        t.data = new_data
+
+        return end
+
+    def erase(self, t: torch.Tensor):
+        assert t in self.record_dict
+
+        new_data = self.record_dict.pop(t)
+        t.data = new_data
+
+        return
+
+    def __repr__(self) -> str:
+        return f'Buffer(size={self.buffer_size}, dtype={self.buffer_dtype}, memo_occ={_format_memory(self.buffer_occ)})'

--- a/elixir/hook/storage.py
+++ b/elixir/hook/storage.py
@@ -1,7 +1,7 @@
 import torch
 from torch.autograd.profiler_util import _format_memory
 
-from elixir import gpu_device
+from elixir.utils import gpu_device
 
 
 class BufferStore(object):

--- a/elixir/wrapper/module.py
+++ b/elixir/wrapper/module.py
@@ -139,6 +139,7 @@ class ElixirModule(nn.Module):
 
         with torch._C.DisableTorchFunction():
             chunk = self.fetcher.get_one_chunk(param)
+            assert self.fetcher.group.is_accessed(chunk)
             if chunk.tensors_info[param].state != TensorState.HOLD_AFTER_BWD:
                 raise RuntimeError()
             self.fetcher.group.tensor_trans_state(param, TensorState.READY_FOR_REDUCE)

--- a/elixir/wrapper/module.py
+++ b/elixir/wrapper/module.py
@@ -10,8 +10,8 @@ from torch.utils._pytree import tree_map
 
 from elixir.chunk import Chunk, ChunkFetcher, ChunkGroup, MemoryPool, TensorState
 from elixir.chunk.scheduler import FIFOScheduler, PrefetchScheduler
-from elixir.hook import HookParam
-from elixir.parameter import FakeTensor, OutplaceTensor
+from elixir.hook import BufferStore, HookParam
+from elixir.parameter import OutplaceTensor
 from elixir.search import SearchResult
 from elixir.utils import gpu_device
 
@@ -55,6 +55,7 @@ class ElixirModule(nn.Module):
         self.grad_state_dict = dict()
         self.__init_chunk_group(search_result)
         self.__init_chunk_fetcher(search_result, prefetch)
+        self.__init_buffer_storage()
 
         for name, param in module.named_parameters():
             if not param.requires_grad:
@@ -132,6 +133,19 @@ class ElixirModule(nn.Module):
 
         self.fetcher = ChunkFetcher(scheduler, self.param_chunk_group, overlap=prefetch)
 
+    def __init_buffer_storage(self):
+        buffer_size = 0
+        for submodule in self.modules():
+            sum_param_size = 0
+            for param in submodule.parameters(recurse=False):
+                if not param.requires_grad or self.fetcher.is_in_fused(param):
+                    continue
+                assert param.dtype == self.dtype
+                sum_param_size += param.numel()
+            buffer_size = max(buffer_size, sum_param_size)
+        self.buffer = BufferStore(buffer_size, self.dtype)
+        print('module buffer', self.buffer)
+
     def _gradient_handler(self, grad: torch.Tensor, param: nn.Parameter):
         # create an empty tensor
         empty_grad = torch.empty_like(grad)
@@ -160,7 +174,7 @@ class ElixirModule(nn.Module):
 
     def forward(self, *args, **kwargs):
         self.fetcher.reset()
-        HookParam.attach_fetcher(self.fetcher)
+        HookParam.attach_fetcher(self.fetcher, self.buffer)
 
         def to_outplace_tensor(t):
             if torch.is_tensor(t):

--- a/test/chunk/test_fetcher.py
+++ b/test/chunk/test_fetcher.py
@@ -36,7 +36,7 @@ def exam_chunk_fetcher(nproc, group):
     data = data.cuda()
 
     seed_all(1001, cuda_deterministic=True)
-    ddp_model = DDP(torch_model, bucket_cap_mb=0)
+    ddp_model = DDP(torch_model)
     ddp_loss = ddp_model(data).sum()
     ddp_loss.backward()
 
@@ -59,7 +59,7 @@ def run_dist(rank, world_size):
     exam_chunk_fetcher(nproc=world_size, group=dist.GroupMember.WORLD)
 
 
-@pytest.mark.dist
+@pytest.mark.skip(reason='remove temp.py in elixir.hook and use ElixirModule instead')
 @pytest.mark.parametrize('world_size', [1, 2, 4])
 def test_chunk_fetcher(world_size):
     run_func = partial(run_dist, world_size=world_size)

--- a/test/chunk/test_fetcher.py
+++ b/test/chunk/test_fetcher.py
@@ -25,7 +25,7 @@ def check_gradient(ddp_model, my_model, cg: ChunkGroup):
 
 
 def exam_chunk_fetcher(nproc, group):
-    builder, train_iter, test_iter, criterion = TEST_MODELS.get_func('mlp')()
+    builder, train_iter, test_iter, criterion = TEST_MODELS.get_func('resnet')()
     torch_model = builder().cuda()
     test_model = copy.deepcopy(torch_model)
 
@@ -35,8 +35,8 @@ def exam_chunk_fetcher(nproc, group):
     data, label = next(train_iter)
     data = data.cuda()
 
-    seed_all(1001)
-    ddp_model = DDP(torch_model)
+    seed_all(1001, cuda_deterministic=True)
+    ddp_model = DDP(torch_model, bucket_cap_mb=0)
     ddp_loss = ddp_model(data).sum()
     ddp_loss.backward()
 

--- a/test/wrapper/test_module.py
+++ b/test/wrapper/test_module.py
@@ -76,7 +76,7 @@ def exam_one_module_fwd_bwd(builder, train_iter, nproc, group, exam_seed=2261):
 
 
 def exam_modules_fwd_bwd(nproc, group):
-    builder, train_iter, test_iter, criterion = TEST_MODELS.get_func('small')()
+    builder, train_iter, test_iter, criterion = TEST_MODELS.get_func('resnet')()
     exam_one_module_fwd_bwd(builder, train_iter, nproc, group)
 
 
@@ -87,8 +87,8 @@ def run_dist(rank, world_size):
     os.environ['MASTER_ADDR'] = '127.0.0.1'
     os.environ['MASTER_PORT'] = str(29512)
     init_distributed()
-    # exam_module_init(nproc=world_size, group=dist.GroupMember.WORLD, grad_flag=False)
-    # exam_module_init(nproc=world_size, group=dist.GroupMember.WORLD, grad_flag=True)
+    exam_module_init(nproc=world_size, group=dist.GroupMember.WORLD, grad_flag=False)
+    exam_module_init(nproc=world_size, group=dist.GroupMember.WORLD, grad_flag=True)
     exam_modules_fwd_bwd(nproc=world_size, group=dist.GroupMember.WORLD)
 
 

--- a/test/wrapper/test_module.py
+++ b/test/wrapper/test_module.py
@@ -6,12 +6,35 @@ from test.utils import TEST_MODELS, assert_dict_values
 import pytest
 import torch
 import torch.distributed as dist
+import torch.nn as nn
 from torch.nn.parallel import DistributedDataParallel as DDP
 from torch.testing import assert_close
 
 from elixir.search import simple_search
 from elixir.utils import init_distributed, seed_all
 from elixir.wrapper import ElixirModule
+
+
+def check_gradient(ddp_model: nn.Module, test_model: ElixirModule):
+    name_to_grad = {name: param.grad for name, param in ddp_model.named_parameters()}
+    param_to_name = {test_model.grad_state_dict[name]: name for name in name_to_grad}
+
+    def check_chunks(cg, chunks):
+        for c in chunks:
+            cg.access_chunk(c)
+            for t in c.get_tensors():
+                name = param_to_name[t]
+                grad = name_to_grad[name]
+
+                torch.cuda.synchronize()
+                print(f'checking the gradient of parameter `{name}`')
+                assert_close(t.data, grad.data)
+
+            if not c.rcache_fused:
+                cg.release_chunk(c)
+
+    check_chunks(test_model.param_chunk_group, test_model.param_chunk_group.fused_chunks)
+    check_chunks(test_model.param_chunk_group, test_model.param_chunk_group.float_chunks)
 
 
 def exam_module_init(nproc, group, grad_flag):
@@ -21,12 +44,40 @@ def exam_module_init(nproc, group, grad_flag):
         param.requires_grad = grad_flag
     test_model = copy.deepcopy(torch_model)
 
-    sr = simple_search(test_model, nproc, 10)
+    sr = simple_search(test_model, nproc)
     model = ElixirModule(test_model, sr, group)
     # check function: ElixirModule.state_dict after ElixirModule.__init__
     torch_st = torch_model.state_dict()
     test_st = model.state_dict()
     assert_dict_values(torch_st, test_st, fn=torch.equal)
+
+
+def exam_one_module_fwd_bwd(builder, train_iter, nproc, group, exam_seed=2261):
+    ddp_model = builder().cuda()
+    test_model = copy.deepcopy(ddp_model)
+    sr = simple_search(test_model, nproc, allocate_factor=0.6)
+    test_model = ElixirModule(test_model, sr, group)
+
+    # get different data
+    seed_all(exam_seed + dist.get_rank(group))
+    data, label = next(train_iter)
+    data = data.cuda()
+
+    seed_all(exam_seed, cuda_deterministic=True)
+    ddp_model = DDP(ddp_model)
+    ddp_loss = ddp_model(data).sum()
+    ddp_loss.backward()
+
+    test_loss = test_model(data).sum()
+    test_model.backward(test_loss)
+
+    assert_close(ddp_loss, test_loss)
+    check_gradient(ddp_model.module, test_model)
+
+
+def exam_modules_fwd_bwd(nproc, group):
+    builder, train_iter, test_iter, criterion = TEST_MODELS.get_func('small')()
+    exam_one_module_fwd_bwd(builder, train_iter, nproc, group)
 
 
 def run_dist(rank, world_size):
@@ -36,8 +87,9 @@ def run_dist(rank, world_size):
     os.environ['MASTER_ADDR'] = '127.0.0.1'
     os.environ['MASTER_PORT'] = str(29512)
     init_distributed()
-    exam_module_init(nproc=world_size, group=dist.GroupMember.WORLD, grad_flag=False)
-    exam_module_init(nproc=world_size, group=dist.GroupMember.WORLD, grad_flag=True)
+    # exam_module_init(nproc=world_size, group=dist.GroupMember.WORLD, grad_flag=False)
+    # exam_module_init(nproc=world_size, group=dist.GroupMember.WORLD, grad_flag=True)
+    exam_modules_fwd_bwd(nproc=world_size, group=dist.GroupMember.WORLD)
 
 
 @pytest.mark.dist
@@ -48,4 +100,4 @@ def test_elixir_module(world_size):
 
 
 if __name__ == '__main__':
-    test_elixir_module(world_size=2)
+    test_elixir_module(world_size=1)


### PR DESCRIPTION
### What's New

The previous implementation faced gradient error in the backward pass. The reason is that intermidiate variable saved for backward pointed to one single block but this block is reused by other chunk later, which makes inappropriate memory access. To deal with this problem, I introduced a buffer to store parameters when computing. This makes parameters use the same footprint in the backward pass. Thus, we can modify the buffer to change those intermidiate variable correct in computing.